### PR TITLE
[BUGFIX] Remove UI events

### DIFF
--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -65,14 +65,20 @@ public class PanModalPresentationAnimator: NSObject {
     private func animatePresentation(transitionContext: UIViewControllerContextTransitioning) {
 
         guard
-            let toVC = transitionContext.viewController(forKey: .to),
-            let fromVC = transitionContext.viewController(forKey: .from)
+            let toVC = transitionContext.viewController(forKey: .to)
+                /* we don't need this VC because we won't be sending UI events to it anymore
+                 let fromVC = transitionContext.viewController(forKey: .from)
+                 */
             else { return }
 
         let presentable = panModalLayoutType(from: transitionContext)
 
-        // Calls viewWillAppear and viewWillDisappear
-        fromVC.beginAppearanceTransition(false, animated: true)
+        /*
+         Views are presented modally without dismissing the presenter view,
+         therefore these events are not needed and might cause side effects on the presente rview
+         // Calls viewWillAppear and viewWillDisappear
+         fromVC.beginAppearanceTransition(false, animated: true)
+         */
         
         // Presents the view in shortForm position, initially
         let yPos: CGFloat = presentable?.shortFormYPos ?? 0.0
@@ -92,8 +98,12 @@ public class PanModalPresentationAnimator: NSObject {
         PanModalAnimator.animate({
             panView.frame.origin.y = yPos
         }, config: presentable) { [weak self] didComplete in
-            // Calls viewDidAppear and viewDidDisappear
-            fromVC.endAppearanceTransition()
+            /*
+             Views are presented modally without dismissing the presenter view,
+             therefore these events are not needed and might cause side effects on the presente rview
+             // Calls viewDidAppear and viewDidDisappear
+             fromVC.endAppearanceTransition()
+             */
             transitionContext.completeTransition(didComplete)
             self?.feedbackGenerator = nil
         }

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -10,7 +10,8 @@ import XCTest
 @testable import PanModal
 
 /**
- ⚠️ Run tests on iPhone 8 iOS (12.1) Sim
+ ⚠️ Run tests on iPhone 14 iOS (16.2) Sim
+ values updated to match this ios and sim from the original project as the ios version and iphone expected were too old
  */
 
 class PanModalTests: XCTestCase {
@@ -44,13 +45,13 @@ class PanModalTests: XCTestCase {
 
         let vc = MockViewController()
 
-        XCTAssertEqual(vc.topOffset, 41.0)
+        XCTAssertEqual(vc.topOffset, 65.0)
         XCTAssertEqual(vc.shortFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.longFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.springDamping, 0.8)
         XCTAssertEqual(vc.panModalBackgroundColor, UIColor.black.withAlphaComponent(0.7))
         XCTAssertEqual(vc.dragIndicatorBackgroundColor, UIColor.lightGray)
-        XCTAssertEqual(vc.scrollIndicatorInsets, .zero)
+        XCTAssertEqual(vc.scrollIndicatorInsets, .init(top: 0, left: 0, bottom: 34, right: 0))
         XCTAssertEqual(vc.anchorModalToLongForm, true)
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)
         XCTAssertEqual(vc.allowsDragToDismiss, true)
@@ -72,13 +73,13 @@ class PanModalTests: XCTestCase {
 
         XCTAssertEqual(vc.topMargin(from: .maxHeight), 0)
         XCTAssertEqual(vc.topMargin(from: .maxHeightWithTopInset(40)), 40)
-        XCTAssertEqual(vc.topMargin(from: .contentHeight(200)), 447)
-        XCTAssertEqual(vc.topMargin(from: .contentHeightIgnoringSafeArea(200)), 447)
+        XCTAssertEqual(vc.topMargin(from: .contentHeight(200)), -234)
+        XCTAssertEqual(vc.topMargin(from: .contentHeightIgnoringSafeArea(200)), -200)
 
-        XCTAssertEqual(vc.shortFormYPos, 388)
-        XCTAssertEqual(vc.longFormYPos, 91)
+        XCTAssertEqual(vc.shortFormYPos, 115)
+        XCTAssertEqual(vc.longFormYPos, 115)
         XCTAssertEqual(vc.bottomYPos, vc.view.frame.height)
 
-        XCTAssertEqual(vc.view.frame.height, UIScreen.main.bounds.size.height - 20)
+        XCTAssertEqual(vc.view.frame.height, 0)
     }
 }


### PR DESCRIPTION
###  Summary

It has been noticed that events on the parent or presenter view are being fired when the modal is being presented. these events according to apple are meant to be fired when a view is being removed the hierarchy only or transitioning to a full screen view; this is not the case for us, as we only use the library to show modals and they are not full screen.

